### PR TITLE
Shops

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,9 +1,9 @@
 # Towny-TNE by LlmDl
 
 ## Overview
-Towny-TNE is a plugin made to bridge Towny and The New Economy.
+### Towny-TNE is a plugin made to bridge Towny and The New Economy.
 
-This plugin brings awareness of Towny locations to TNE's Mobs module and Currency Notes to allow for 2 features:
+#### This plugin brings awareness of Towny locations to TNE's Mobs module and Currency Notes to allow for 2 features:
 
 * The ability to penalize player's money rewards when not in the wilderness, and not in an exempted town.
   * The config's Exempted Towns list can be used to exempt towns from the penalty, useful for admins who want their spawn town's mob arena to not lessen money rewards.
@@ -12,6 +12,12 @@ This plugin brings awareness of Towny locations to TNE's Mobs module and Currenc
 * The ability to limit the players' ability to 'use' their Currency Notes to only Towny Bank Plots.
   * This increases Role Playing, you must go to a bank plot to deposit/collect your virtual money from the physical Currency Notes.
   * It increases risk on PVP servers where someone could rob you of your undeposit/uncollected Currency Notes.
+
+### This plugin also has the ability to interact with TNE's Signs module to allow the following:
+
+* The ability to limit creation of TNE sign shops to Towny shop plots.
+  * You can optionally limit the creation of shops to only shop plots owned by the player, or
+  * You can limit it to shop plots where the creator is able to also build (allowing for group-owned shop plots.)
 
 ## Installation
 Simply add the Towny-TNE.jar to your server's plugins folder.
@@ -22,9 +28,13 @@ Read the config's comments and choose which worlds you might want to disable thi
 
 Set the ```Inside_Town_Multiplier``` to what you want, choose whether you want to limit the use of CurrencyNotes to only bank plots using the ```Deny_Currency_Note_Claiming_Outside_Bank_Plots``` option.
 
+Set the ```Enforce_Shop_Plots``` to true or false if you'd like to enable the limitation of sign shops to shop plots.
+
+Set the ```Require_Shop_Plot_Ownership``` to true if you'd like players to only be able to make sign shops in shop plots they personally own. 
+
 After saving the config use /towny-tne reload to reload the config.
 
-Read the below requirements to make sure you're using the required versions of Towny, TNE, and TNE's Mobs module.
+__Read the below requirements to make sure you're using the required versions of Towny, TNE, and TNE's Mobs module.__
 
 ## Upgrading
 Towny-TNE uses the commentedconfiguration developed by dumptruckman, so you won't have to worry about your config when updating Towny-TNE.
@@ -32,11 +42,12 @@ Towny-TNE uses the commentedconfiguration developed by dumptruckman, so you won'
 New config values will be added with default settings and your old settings will be left intact.
 
 ## Requirements
-Your server must be using the following versions or newer:
+Your server __must__ be using the following versions or newer:
 
-* Towny 0.94.0.2 (Which should only be used on MC 1.14.* or newer.)
-* TNE 0.1.1.8M4
+* Towny 0.94.0.11 (Which should only be used on MC 1.14.* or newer.)
+* TNE 0.1.1.9
 * TNE's Mobs module 0.1.3.0 
+* TNE's Signs module 0.0.1.3
 
 ## Commands
 * /towny-tne - displays plugin version
@@ -47,4 +58,18 @@ Your server must be using the following versions or newer:
 * townytne.reload - allows use of ```/towny-tne reload```, defaults to ops.
 
 ## Credits
-Obviously me, LlmDl, lead developer of Towny Advanced. As well as creatorfromhell, author of TheNewEconomy, who helped this make this plugin possible with the addition of key events to Mobs and TNE. Also worth mentioning is dumptruckman, who is responsible for the code used to make the config.  
+Obviously me, LlmDl, lead developer of Towny Advanced. As well as creatorfromhell, author of TheNewEconomy, who helped this make this plugin possible with the addition of key events to Mobs and TNE. Also worth mentioning is dumptruckman, who is responsible for the code used to make the config.
+
+## Changelog:
+v1.0:  
+
+  - Initial version.
+  - Currency notes can be limited to Bank plots.
+  - Currency drops can be altered inside towns, while exempting a list of towns.
+  - Currency notes and drops manipulation can be disabled in a list of worlds.
+
+v1.1:
+
+  - Item Sign shop creation can be limited to just Shop plots.
+    - Optionally it can be a personally owned shop plot, or any shop plot where the creator can build.
+  - Made disabledWorlds tests also ignore worlds where usingTowny is false.

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.llmdlio</groupId>
   <artifactId>Towny-TNE</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
   <name>Towny-TNE</name>
-  <description>A plugin that provides Towny-enabled manipulation of TNEMobs' drops.</description>
+  <description>A plugin that provides Towny-location awareness to TheNewEconomy.</description>
     <properties>
       <java.version>1.8</java.version>
       <project.bukkitAPIVersion>1.14</project.bukkitAPIVersion>
@@ -30,9 +30,13 @@
   </build>
   <repositories>
     <repository>
-      <id>tne-repo</id>
-      <url>https://dl.bintray.com/theneweconomy/java/</url>
+      <id>github-TNE</id>
+      <url>https://maven.pkg.github.com/TheNewEconomy/TNE-Bukkit</url>
     </repository>
+    <repository>
+      <id>github-Towny</id>
+      <url>https://maven.pkg.github.com/TownyAdvanced/Towny</url>
+    </repository>   
     <repository>
 	  <id>spigot-repo</id>
 	  <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -47,11 +51,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.palmergames</groupId>
+      <groupId>com.palmergames.bukkit.towny</groupId>
       <artifactId>Towny</artifactId>
-      <version>0.94.0.5</version>
-      <scope>system</scope>
-      <systemPath>C:\Users\Workstation\git\Towny\target\Towny-0.94.0.8.jar</systemPath>
+      <version>0.94.0.12</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.tnemc</groupId>
@@ -62,7 +65,7 @@
     <dependency>
       <groupId>net.tnemc</groupId>
       <artifactId>TNE</artifactId>
-      <version>1.1.8.26</version>
+      <version>1.1.8.28</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>  

--- a/src/main/java/com/gmail/llmdlio/townytne/CurrencyNoteListener.java
+++ b/src/main/java/com/gmail/llmdlio/townytne/CurrencyNoteListener.java
@@ -1,11 +1,13 @@
 package com.gmail.llmdlio.townytne;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 
@@ -21,23 +23,22 @@ public class CurrencyNoteListener implements Listener{
     }
 
     @EventHandler (priority = EventPriority.NORMAL)
-    public void cashedNoteEvent (TNECurrencyNoteClaimedEvent event) {
+    public void cashedNoteEvent (TNECurrencyNoteClaimedEvent event) throws NotRegisteredException {
         Location loc = event.getPlayer().getLocation();
-        if (TownyTNE.disabledWorlds.contains(loc.getWorld().getName()))
+        if (TownyTNE.disabledWorlds.contains(loc.getWorld().getName()) || !TownyAPI.getInstance().getDataSource().getWorld(loc.getWorld().getName()).isUsingTowny())
             return;
 
         if (TownyAPI.getInstance().isWilderness(loc)) {
-            event.getPlayer().sendMessage("You cannot deposit your currency note outside of a town's Bank plot.");
+        	event.getPlayer().sendMessage(ChatColor.DARK_RED + "You cannot deposit your currency note outside of a town's Bank plot.");
             event.setCancelled(true);
             return;
-        } else {
+    	} else {
             TownBlock townBlock = TownyAPI.getInstance().getTownBlock(loc);
             if (!townBlock.getType().equals(TownBlockType.BANK)) {
-                event.getPlayer().sendMessage("You cannot deposit your currency note outside of a town's Bank plot.");
-                event.setCancelled(true);
-                return;
-            } else
-                return;
+            	event.getPlayer().sendMessage(ChatColor.DARK_RED + "You cannot deposit your currency note outside of a town's Bank plot.");
+            	event.setCancelled(true);
+            	return;
+            }
         }
     }
 }

--- a/src/main/java/com/gmail/llmdlio/townytne/ShopListener.java
+++ b/src/main/java/com/gmail/llmdlio/townytne/ShopListener.java
@@ -1,0 +1,50 @@
+package com.gmail.llmdlio.townytne;
+
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.utils.ShopPlotUtil;
+
+import net.tnemc.core.event.module.TNEModuleDataEvent;
+
+public class ShopListener implements Listener{
+
+    @SuppressWarnings("unused")
+	private TownyTNE plugin;
+    
+    public ShopListener (TownyTNE instance) {
+        this.plugin = instance;
+    }
+
+    @EventHandler (priority = EventPriority.NORMAL)
+    public void onShopCreate (TNEModuleDataEvent event) throws NotRegisteredException {
+
+    	if (!event.getEventName().equals("SignCreate"))
+    		return;
+    	if (!event.getData().get("type").equals("item"))
+    		return;
+        Location loc = (Location) event.getData().get("location");
+        if (TownyTNE.disabledWorlds.contains(loc.getWorld().getName()) || !TownyAPI.getInstance().getDataSource().getWorld(loc.getWorld().getName()).isUsingTowny())
+        	return;
+        Player player = Bukkit.getPlayer((UUID) event.getData().get("creator"));
+        boolean allowedShopCreation = false;
+        if (TownyTNE.requireShopPlotOwnership)
+            allowedShopCreation = ShopPlotUtil.doesPlayerOwnShopPlot(player, loc);
+        else 
+            allowedShopCreation = ShopPlotUtil.doesPlayerHaveAbilityToEditShopPlot(player, loc);
+
+        if (!allowedShopCreation) {
+        	player.sendMessage(ChatColor.DARK_RED + "Your shop must be made inside of a Shop plot " + (TownyTNE.requireShopPlotOwnership ? "that you own." : "where you can build."));
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/com/gmail/llmdlio/townytne/config/TownyTNEConfig.java
+++ b/src/main/java/com/gmail/llmdlio/townytne/config/TownyTNEConfig.java
@@ -48,20 +48,20 @@ public class TownyTNEConfig {
             e.printStackTrace(); 
         }
 
-        addComment("Version","  # Towny-TNEMobs-Bridge by LlmDl."); 
-
-        addDefault("Version", plugin.getDescription().getVersion()); 
+        addComment("Version","  # Towny-TNEMobs-Bridge by LlmDl.");
+        addDefault("Version", ""); 
 
         addComment("Disabled_Worlds", newline, 
-                "  # A list of worlds where players are not penalized for killing things with lesser money drops.",
-                "  # Disabled Worlds:",
+                "  # A list of worlds which will not be affected by this plugin.",
+                "  # Any world in which Towny has usingTowny=false will already be disabled automatically.",
+                "  # Disabled_Worlds:",
                 "  # - world",
                 "  # - world_nether");
         addDefault("Disabled_Worlds", new ArrayList<String>());
 
         addComment("Exempted_Towns", newline, 
                 "  # A list of towns in which players are not penalized for killing things with lesser money drops.",
-                "  # Exempted Towns:",
+                "  # Exempted_Towns:",
                 "  # - SpawnTown",
                 "  # - Best_Town_on_Dah_Server");
         addDefault("Exempted_Towns", new ArrayList<String>());
@@ -76,6 +76,16 @@ public class TownyTNEConfig {
         addComment("Deny_Currency_Note_Claiming_Outside_Bank_Plots", newline,
                 "  # When set to true TNE Currency Notes will only be usable while inside Towny Bank plots.");
         addDefault("Deny_Currency_Note_Claiming_Outside_Bank_Plots", false);
+        
+        addComment("Enforce_Shop_Plots", newline, 
+                "  # Restrict TNE shops to Towny shop plots.");
+        addDefault("Enforce_Shop_Plots", false);
+        
+        addComment("Require_Shop_Plot_Ownership", newline,
+                "  # When Enforce_Shop_Plots is true, do we require the shop-maker to personally own the Towny shop plot.",
+                "  # If true, they must own it. If false, they must be able to build at the shop location.",
+                "  # Set to false if you want to have shared/group shop plots.");
+        addDefault("Require_Shop_Plot_Ownership", true);
 
         // Write back config 
         try { 
@@ -98,7 +108,9 @@ public class TownyTNEConfig {
     }
 
     private void addDefault(String path, Object defaultValue) {
-        if (!hasPath(path))
+    	if (path.equals("Version"))
+    		config.set(path, plugin.getDescription().getVersion());
+    	else if (!hasPath(path))
             config.set(path, defaultValue);
     }
 }

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,9 +1,9 @@
-v1.0:
-  - First version.
-  - Plugin can prevent currency notes from being used outside of bank plots.
-  - Plugin can lessen/penalize note values based on whether entity killed was in town or wilderness.
-    - There is a list of towns that will not be penalized.
-  - There is a list of worlds which this plugin will ignore.
+v1.0:  
+  - Initial version.
+  - Currency notes can be limited to Bank plots.
+  - Currency drops can be altered inside towns, while exempting a list of towns.
+  - Currency notes and drops manipulation can be disabled in a list of worlds.
 v1.1:
-  - Plugin can prevent shops being made outside of shop plots.
-  - Worlds that have towny disabled are automatically included in the disabled worlds list.
+  - Item Sign shop creation can be limited to just Shop plots.
+    - Optionally it can be a personally owned shop plot, or any shop plot where the creator can build.
+  - Made disabledWorlds tests also ignore worlds where usingTowny is false.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,0 +1,9 @@
+v1.0:
+  - First version.
+  - Plugin can prevent currency notes from being used outside of bank plots.
+  - Plugin can lessen/penalize note values based on whether entity killed was in town or wilderness.
+    - There is a list of towns that will not be penalized.
+  - There is a list of worlds which this plugin will ignore.
+v1.1:
+  - Plugin can prevent shops being made outside of shop plots.
+  - Worlds that have towny disabled are automatically included in the disabled worlds list.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}
 api-version: ${project.bukkitAPIVersion}
 author: LlmDl
 depend: [Towny,TheNewEconomy]
-description: Bridge plugin to make Towny locations affect TNEMob payouts
+description: A plugin that provides Towny-location awareness to TheNewEconomy.
 prefix: Towny-TNE
 commands:
   towny-tne:


### PR DESCRIPTION
  - Item Sign shop creation can be limited to just Shop plots.
    - Optionally it can be a personally owned shop plot, or any shop
plot where the creator can build.
  - Made disabledWorlds tests also ignore worlds where usingTowny is
false.
